### PR TITLE
Update to use TriggerContextData and disable deno lock

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,5 +1,6 @@
 {
   "importMap": "import_map.json",
+  "lock": false,
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test --allow-read --allow-none"
   }

--- a/triggers/submit_issue.ts
+++ b/triggers/submit_issue.ts
@@ -1,5 +1,5 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData } from "deno-slack-api/mod.ts";
+import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
 import SubmitIssueWorkflow from "../workflows/submit_issue.ts";
 
 /**
@@ -9,7 +9,7 @@ import SubmitIssueWorkflow from "../workflows/submit_issue.ts";
  * https://api.slack.com/automation/triggers
  */
 const submitIssue: Trigger<typeof SubmitIssueWorkflow.definition> = {
-  type: "shortcut",
+  type: TriggerTypes.Shortcut,
   name: "Submit an issue",
   description: "Submit an issue to the channel",
   workflow: "#/workflows/submit_issue",

--- a/triggers/submit_issue.ts
+++ b/triggers/submit_issue.ts
@@ -1,4 +1,5 @@
-import { Trigger } from "deno-slack-api/types.ts";
+import { Trigger } from "deno-slack-sdk/types.ts";
+import { TriggerContextData } from "deno-slack-api/mod.ts";
 import SubmitIssueWorkflow from "../workflows/submit_issue.ts";
 
 /**
@@ -14,10 +15,10 @@ const submitIssue: Trigger<typeof SubmitIssueWorkflow.definition> = {
   workflow: "#/workflows/submit_issue",
   inputs: {
     interactivity: {
-      value: "{{data.interactivity}}",
+      value: TriggerContextData.Shortcut.interactivity,
     },
     channel: {
-      value: "{{data.channel_id}}",
+      value: TriggerContextData.Shortcut.channel_id,
     },
   },
 };

--- a/workflows/submit_issue.ts
+++ b/workflows/submit_issue.ts
@@ -19,7 +19,7 @@ const SubmitIssueWorkflow = DefineWorkflow({
         type: Schema.slack.types.channel_id,
       },
     },
-    required: ["channel"],
+    required: ["channel", "interactivity"],
   },
 });
 


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

Use the `TriggerTypes` object, the `TriggerContextData` object instead of using the templatized strings like `{{data.interactivity}}`, and disable `deno.lock` based on recent convos

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
