### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,9 +30,9 @@
     "test": "deno fmt --check && deno lint && deno test --allow-read"
   },
   "imports": {
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
     "@std/assert": "jsr:@std/assert@^1.0.15",
-    "@std/testing": "jsr:@std/testing@^1.0.16",
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/"
+    "@std/testing": "jsr:@std/testing@^1.0.16"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,7 +31,7 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2",
     "@std/assert": "jsr:@std/assert@^1.0.15",
     "@std/testing": "jsr:@std/testing@^1.0.16"
   }

--- a/functions/post_issue_message.ts
+++ b/functions/post_issue_message.ts
@@ -1,5 +1,5 @@
-import { DefineFunction, Schema } from "deno-slack-sdk/mod.ts";
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema } from "@slack/sdk";
+import { SlackFunction } from "@slack/sdk";
 
 /**
  * Functions are reusable building blocks of automation that accept

--- a/functions/post_issue_message_test.ts
+++ b/functions/post_issue_message_test.ts
@@ -1,4 +1,4 @@
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import handler from "./post_issue_message.ts";
 import { stub } from "@std/testing/mock";
 import { assertEquals } from "@std/assert/equals";

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 import { PostIssueMessage } from "./functions/post_issue_message.ts";
 import SubmitIssueWorkflow from "./workflows/submit_issue.ts";
 

--- a/triggers/submit_issue.ts
+++ b/triggers/submit_issue.ts
@@ -1,5 +1,5 @@
-import type { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import type { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import type SubmitIssueWorkflow from "../workflows/submit_issue.ts";
 
 /**

--- a/workflows/submit_issue.ts
+++ b/workflows/submit_issue.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { PostIssueMessage } from "../functions/post_issue_message.ts";
 
 /**


### PR DESCRIPTION
Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

Made with [Cursor](https://cursor.com)